### PR TITLE
Add translation for Portuguese and Spanish languages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
         "p-limit": "4.0.0",
         "p-memoize": "6.0.1",
         "package-license-types": "1.0.1",
+        "preferred-locale": "^1.0.10",
+        "pupa": "^3.1.0",
         "random-item": "4.0.1",
         "s-ago": "2.2.0",
         "strip-json-comments": "4.0.0",
@@ -1806,6 +1808,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-goat": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-4.0.0.tgz",
+      "integrity": "sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -3059,6 +3072,17 @@
         "url": "https://opencollective.com/postcss/"
       }
     },
+    "node_modules/preferred-locale": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/preferred-locale/-/preferred-locale-1.0.10.tgz",
+      "integrity": "sha512-auxsI0h2FuPfUdit7u/+VyoSDVEgTA2fWfp9fd51e6Jb7nnXQuhqc0u0BnUPgPliNANvnp78pqg15xPwvVmqMw==",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/wopian"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.4.6",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.6.tgz",
@@ -3119,6 +3143,20 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/pupa": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-3.1.0.tgz",
+      "integrity": "sha512-FLpr4flz5xZTSJxSeaheeMKN/EDzMdK7b8PTOC6a5PYFKTucWbdqjgqaEyH0shFiSJrVB1+Qqi4Tk19ccU6Aug==",
+      "dependencies": {
+        "escape-goat": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/queue-microtask": {
@@ -5095,6 +5133,11 @@
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true
     },
+    "escape-goat": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-4.0.0.tgz",
+      "integrity": "sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg=="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -6012,6 +6055,11 @@
         "source-map-js": "^1.0.1"
       }
     },
+    "preferred-locale": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/preferred-locale/-/preferred-locale-1.0.10.tgz",
+      "integrity": "sha512-auxsI0h2FuPfUdit7u/+VyoSDVEgTA2fWfp9fd51e6Jb7nnXQuhqc0u0BnUPgPliNANvnp78pqg15xPwvVmqMw=="
+    },
     "pretty-format": {
       "version": "27.4.6",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.6.tgz",
@@ -6062,6 +6110,14 @@
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "pupa": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-3.1.0.tgz",
+      "integrity": "sha512-FLpr4flz5xZTSJxSeaheeMKN/EDzMdK7b8PTOC6a5PYFKTucWbdqjgqaEyH0shFiSJrVB1+Qqi4Tk19ccU6Aug==",
+      "requires": {
+        "escape-goat": "^4.0.0"
       }
     },
     "queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "p-limit": "4.0.0",
     "p-memoize": "6.0.1",
     "package-license-types": "1.0.1",
+    "preferred-locale": "^1.0.10",
+    "pupa": "^3.1.0",
     "random-item": "4.0.1",
     "s-ago": "2.2.0",
     "strip-json-comments": "4.0.0",

--- a/src/components/App.svelte
+++ b/src/components/App.svelte
@@ -5,6 +5,7 @@
   import FloatingSideButtons from "./buttons/FloatingSideButtons.svelte";
   import { afterUpdate } from "svelte";
   import { lazyLoad } from "../constants/lazyLoad";
+  import { getTranslation, TranslationId } from "../modules/translations";
 
   afterUpdate(() => lazyLoad.update());
 </script>
@@ -40,8 +41,7 @@
               </a>
               <div>
                 <span>
-                  Discover similar packages from your
-                  <em>package.json</em> dependencies.
+                  {@html getTranslation(TranslationId.AppDescription)}
                 </span>
               </div>
             </div>

--- a/src/components/DependenciesTable.svelte
+++ b/src/components/DependenciesTable.svelte
@@ -6,6 +6,7 @@
   import { dependenciesFromPackage } from "../stores/dependenciesFromPackage";
   import { getSimilarPackagesNames } from "../functions/getSimilarPackagesNames";
   import { fetchPackage } from "../functions/fetchPackage";
+  import { getTranslation, TranslationId } from "../modules/translations";
 
   const similarPackagesToDisplayPerBatch = 5;
   let dependencyPerSimilarPackagesDisplayedMap = {};
@@ -16,8 +17,8 @@
     <table class="table">
       <thead>
         <tr>
-          <th class="text-center">Installed</th>
-          <th class="text-center">Similar</th>
+          <th class="text-center">{getTranslation(TranslationId.Installed)}</th>
+          <th class="text-center">{getTranslation(TranslationId.Similar)}</th>
         </tr>
       </thead>
       <tbody>
@@ -74,7 +75,7 @@
                             ] ?? similarPackagesToDisplayPerBatch) +
                             similarPackagesToDisplayPerBatch)}
                       >
-                        Show More
+                        {getTranslation(TranslationId.ShowMore)}
                       </button>
                     {/if}
                   {:catch}

--- a/src/components/NoSimilarPackagesSummary.svelte
+++ b/src/components/NoSimilarPackagesSummary.svelte
@@ -1,1 +1,7 @@
-<summary class="collapse-header">No similar packages found.</summary>
+<script>
+  import { getTranslation, TranslationId } from "../modules/translations";
+</script>
+
+<summary class="collapse-header">
+  {getTranslation(TranslationId.NoSimilarPackagesFound)}
+</summary>

--- a/src/components/PackageDetails.svelte
+++ b/src/components/PackageDetails.svelte
@@ -15,6 +15,7 @@
   import NpmButton from "./buttons/NpmButton.svelte";
   import RunkitButton from "./buttons/RunKitButton.svelte";
   import type { SearchResult } from "../types/npms";
+  import { getTranslation, TranslationId } from "../modules/translations";
 
   export let packageSearchResult: SearchResult;
 
@@ -159,7 +160,7 @@
                 if (navigator.clipboard) {
                   copyTextToClipboard(currentTarget.value);
                   halfmoon.initStickyAlert({
-                    title: "Copied to clipboard!",
+                    title: getTranslation(TranslationId.CopiedToClipboard),
                     content: currentTarget.value,
                   });
                 }

--- a/src/components/PackageLoadingProgressBar.svelte
+++ b/src/components/PackageLoadingProgressBar.svelte
@@ -1,7 +1,9 @@
 <div class="progress">
-  <div
-    class="progress-bar progress-bar-animated"
-    role="progressbar"
-    style={`width: 100%`}
-  />
+  <div class="progress-bar progress-bar-animated" role="progressbar" />
 </div>
+
+<style>
+  .progress-bar {
+    width: 100%;
+  }
+</style>

--- a/src/components/badges/LicenseBadge.svelte
+++ b/src/components/badges/LicenseBadge.svelte
@@ -4,6 +4,8 @@
   import { openWinBox } from "../../functions/openWinBox";
   import { afterUpdate } from "svelte";
   import { lazyLoad } from "../../constants/lazyLoad";
+  import { getTranslation, TranslationId } from "../../modules/translations";
+  import pupa from "pupa";
 
   export let packageName = "npm";
 
@@ -25,16 +27,18 @@
 
       if (licenses.length === 0) throw new Error();
 
-      licenses.forEach((license) => {
+      licenses.forEach((licenseName) => {
         openWinBox({
-          url: `https://spdx.org/licenses/${license}.html#licenseText`,
-          title: `${license} License`,
+          url: `https://spdx.org/licenses/${licenseName}.html#licenseText`,
+          title: pupa(getTranslation(TranslationId.LicenseName), {
+            licenseName,
+          }),
         });
       });
     } catch {
       openWinBox({
         url: currentTarget.href,
-        title: "Licenses",
+        title: getTranslation(TranslationId.Licenses),
       });
     }
   }
@@ -42,14 +46,14 @@
 
 <a
   href="https://spdx.org/licenses"
-  title="Click to read about this license"
+  title={getTranslation(TranslationId.ClickToReadAboutLicense)}
   target="_blank"
   on:click|preventDefault={handleClick}
 >
   <img
     on:error={handleImageError}
     data-src="https://badgen.net/npm/license/{packageName}"
-    alt="License"
+    alt={getTranslation(TranslationId.License)}
     class="lazy"
   />
 </a>

--- a/src/components/buttons/ExploreFilesButton.svelte
+++ b/src/components/buttons/ExploreFilesButton.svelte
@@ -1,5 +1,7 @@
 <script>
+  import pupa from "pupa";
   import { openWinBox } from "../../functions/openWinBox";
+  import { getTranslation, TranslationId } from "../../modules/translations";
 
   export let packageName = "npm";
 </script>
@@ -10,8 +12,10 @@
   on:click={() =>
     openWinBox({
       url: `https://www.runpkg.com/?${packageName}/`,
-      title: `${packageName}'s files`,
+      title: pupa(getTranslation(TranslationId.FilesFromPackage), {
+        packageName,
+      }),
     })}
 >
-  Explore Files
+  {getTranslation(TranslationId.ExploreFiles)}
 </button>

--- a/src/components/buttons/FloatingSideButtons.svelte
+++ b/src/components/buttons/FloatingSideButtons.svelte
@@ -4,6 +4,7 @@
   import { faGithub } from "@fortawesome/free-brands-svg-icons";
   import { openWinBox } from "../../functions/openWinBox";
   import halfmoon from "halfmoon";
+  import { getTranslation, TranslationId } from "../../modules/translations";
 </script>
 
 <div class="btn-group-vertical btn-group-sm floating-side-buttons" role="group">
@@ -17,8 +18,8 @@
       })}
     data-toggle="tooltip"
     data-placement="right"
-    data-title="Send Feedback Anonymously"
-    aria-label="Send Feedback Anonymously"
+    data-title={getTranslation(TranslationId.SendFeedbackAnonymously)}
+    aria-label={getTranslation(TranslationId.SendFeedbackAnonymously)}
   >
     <Fa icon={faCommentDots} />
   </button>
@@ -29,8 +30,8 @@
     role="button"
     data-toggle="tooltip"
     data-placement="right"
-    data-title="Project on GitHub"
-    aria-label="Project on GitHub"
+    data-title={getTranslation(TranslationId.ProjectOnGitHub)}
+    aria-label={getTranslation(TranslationId.ProjectOnGitHub)}
   >
     <Fa icon={faGithub} />
   </a>
@@ -41,8 +42,8 @@
     data-test-id="toggle-dark-mode-button"
     data-toggle="tooltip"
     data-placement="right"
-    data-title="Toggle Dark Mode"
-    aria-label="Toggle Dark Mode"
+    data-title={getTranslation(TranslationId.ToggleDarkMode)}
+    aria-label={getTranslation(TranslationId.ToggleDarkMode)}
   >
     <Fa icon={faMoon} />
   </button>

--- a/src/components/buttons/OpenReadmeButton.svelte
+++ b/src/components/buttons/OpenReadmeButton.svelte
@@ -1,5 +1,7 @@
 <script>
+  import pupa from "pupa";
   import { openWinBox } from "../../functions/openWinBox";
+  import { getTranslation, TranslationId } from "../../modules/translations";
 
   export let packageName = "npm";
 </script>
@@ -10,8 +12,10 @@
   on:click={() =>
     openWinBox({
       url: `https://runkit-packages.com/16.x.x/${Date.now()}/${packageName}`,
-      title: `${packageName}'s readme`,
+      title: pupa(getTranslation(TranslationId.ReadmeFromPackage), {
+        packageName,
+      }),
     })}
 >
-  Open Readme
+  {getTranslation(TranslationId.OpenReadme)}
 </button>

--- a/src/constants/tourConfig.ts
+++ b/src/constants/tourConfig.ts
@@ -1,6 +1,7 @@
+import { getTranslation, TranslationId } from "../modules/translations";
+
 export const tourConfig = {
-  title: "Your package.json",
-  intro:
-    "Paste or drop here your package.json to get suggestions for each dependency!",
+  title: getTranslation(TranslationId.TourTitle),
+  intro: getTranslation(TranslationId.TourIntro),
   position: "bottom",
 };

--- a/src/modules/translations.ts
+++ b/src/modules/translations.ts
@@ -1,0 +1,140 @@
+import getPreferredLocale from "preferred-locale";
+
+const translatedLocales = ["en", "pt", "es"] as const;
+
+const preferredLocale = getPreferredLocale(
+  translatedLocales as unknown as string[],
+  translatedLocales[0],
+  {
+    regionLowerCase: true,
+    languageOnly: true,
+  }
+);
+
+type TranslationStrings = {
+  [K in typeof translatedLocales[number]]: string;
+};
+
+export enum TranslationId {
+  AppDescription,
+  Installed,
+  Similar,
+  ShowMore,
+  SendFeedbackAnonymously,
+  ProjectOnGitHub,
+  ToggleDarkMode,
+  CopiedToClipboard,
+  NoSimilarPackagesFound,
+  TourTitle,
+  TourIntro,
+  LicenseName,
+  Licenses,
+  License,
+  ClickToReadAboutLicense,
+  OpenReadme,
+  ReadmeFromPackage,
+  ExploreFiles,
+  FilesFromPackage,
+}
+
+const translations: Record<TranslationId, TranslationStrings> = {
+  [TranslationId.AppDescription]: {
+    en: "Discover similar packages from your <em>package.json</em> dependencies.",
+    pt: "Descubra pacotes semelhantes às dependências do seu <em>package.json</em>.",
+    es: "Descubra paquetes similares a las dependencias de su <em>package.json</em>.",
+  },
+  [TranslationId.Installed]: {
+    en: "Installed",
+    pt: "Instalado",
+    es: "Instalado",
+  },
+  [TranslationId.Similar]: {
+    en: "Similar",
+    pt: "Semelhante",
+    es: "Semejante",
+  },
+  [TranslationId.ShowMore]: {
+    en: "Show More",
+    pt: "Mostrar Mais",
+    es: "Mostrar más",
+  },
+  [TranslationId.SendFeedbackAnonymously]: {
+    en: "Send Feedback Anonymously",
+    pt: "Enviar Comentários Anonimamente",
+    es: "Enviar Comentarios Anónimamente",
+  },
+  [TranslationId.ProjectOnGitHub]: {
+    en: "Project on GitHub",
+    pt: "Projeto no GitHub",
+    es: "Proyecto en GitHub",
+  },
+  [TranslationId.ToggleDarkMode]: {
+    en: "Toggle Dark Mode",
+    pt: "Alternar Modo Escuro",
+    es: "Alternar Modo Oscuro",
+  },
+  [TranslationId.CopiedToClipboard]: {
+    en: "Copied to clipboard!",
+    pt: "Copiado para a área de transferência!",
+    es: "¡Copiado al portapapeles!",
+  },
+  [TranslationId.NoSimilarPackagesFound]: {
+    en: "No similar packages found.",
+    pt: "Nenhum pacote semelhante encontrado.",
+    es: "No se encontraron paquetes similares.",
+  },
+  [TranslationId.TourTitle]: {
+    en: "Your package.json",
+    pt: "Seu package.json",
+    es: "Su paquete.json",
+  },
+  [TranslationId.TourIntro]: {
+    en: "Paste or drop here your package.json to get suggestions for each dependency!",
+    pt: "Cole ou solte aqui seu package.json para obter sugestões para cada dependência!",
+    es: "¡Pegue o suelte aquí su paquete.json para obtener sugerencias para cada dependencia!",
+  },
+  [TranslationId.LicenseName]: {
+    en: "{{licenseName}} License",
+    pt: "Licença {{licenseName}}",
+    es: "Licencia {{licenseName}}",
+  },
+  [TranslationId.Licenses]: {
+    en: "Licenses",
+    pt: "Licenças",
+    es: "Licencias",
+  },
+  [TranslationId.License]: {
+    en: "License",
+    pt: "Licença",
+    es: "Licencia",
+  },
+  [TranslationId.ClickToReadAboutLicense]: {
+    en: "Click to read about this license",
+    pt: "Clique para ler sobre esta licença",
+    es: "Haga clic para leer sobre esta licencia",
+  },
+  [TranslationId.OpenReadme]: {
+    en: "Open Readme",
+    pt: "Abrir Leiame",
+    es: "Abrir Léame",
+  },
+  [TranslationId.ReadmeFromPackage]: {
+    en: "{{packageName}}'s readme",
+    pt: "Leiame de {{packageName}}",
+    es: "Léame de {{packageName}}",
+  },
+  [TranslationId.ExploreFiles]: {
+    en: "Explore Files",
+    pt: "Explorar Arquivos",
+    es: "Explorar Archivos",
+  },
+  [TranslationId.FilesFromPackage]: {
+    en: "{{packageName}}'s files",
+    pt: "Arquivos de {{packageName}}",
+    es: "Archivos de {{packageName}}",
+  },
+};
+
+export function getTranslation(translationId: TranslationId) {
+  return translations[translationId][preferredLocale];
+}


### PR DESCRIPTION
This PR adds translation for Portuguese and Spanish languages.

The preferred language is detected automatically by [preferred-locale](https://www.npmjs.com/package/preferred-locale).

If there's no translation for the user's preferred locale, it falls back to English.