### PR TITLE
Use NPM Registry mirrors instead of NPMS, which is now unmaintained

### DIFF
--- a/src/components/badges/LicenseBadge.svelte
+++ b/src/components/badges/LicenseBadge.svelte
@@ -22,7 +22,7 @@
 
       const packageAnalysis = await analyzePackage(packageName);
 
-      const licenses = packageLicenseTypes(packageAnalysis.collected.metadata);
+      const licenses = packageLicenseTypes(packageAnalysis);
 
       if (licenses.length === 0) throw new Error();
 

--- a/src/constants/npmApi.ts
+++ b/src/constants/npmApi.ts
@@ -1,0 +1,19 @@
+import ky from "ky";
+
+/**
+ * Yarn NPM Registry has no rate-limiter,
+ * but has an issue with CORS when querying a package.
+ */
+export const yarnNpmApi = ky.create({
+  prefixUrl: "https://registry.yarnpkg.com/",
+  timeout: 5 * 60 * 1000,
+});
+
+/**
+ * Cloudflare NPM Registry has CORS enabled on all endpoints,
+ * but has a rate-limiter, so it can't be used for the similar packages search.
+ */
+export const cloudflareNpmApi = ky.create({
+  prefixUrl: "https://registry.npmjs.cf/",
+  timeout: 5 * 60 * 1000,
+});

--- a/src/constants/npmsApi.ts
+++ b/src/constants/npmsApi.ts
@@ -1,6 +1,0 @@
-import ky from "ky";
-
-export const npmsApi = ky.create({
-  prefixUrl: "https://api.npms.io/v2",
-  timeout: 5 * 60 * 1000,
-});

--- a/src/functions/analyzePackage.ts
+++ b/src/functions/analyzePackage.ts
@@ -1,12 +1,12 @@
 import memoizePromise from "p-memoize";
-import { npmsApi } from "../constants/npmsApi";
+import { cloudflareNpmApi } from "../constants/npmApi";
 import { limitNpmsApiCallsConcurrency } from "./limitNpmsApiCallsConcurrency";
 import type { PackageResult } from "../types/npms";
 
 export const analyzePackage = memoizePromise((packageName: string) =>
   limitNpmsApiCallsConcurrency(() =>
-    npmsApi
-      .get(`package/${encodeURIComponent(packageName)}`)
-      .json<PackageResult>()
+    cloudflareNpmApi
+      .get(`${encodeURIComponent(packageName)}/latest`)
+      .json<PackageResult["collected"]>()
   )
 );

--- a/src/functions/fetchPackage.ts
+++ b/src/functions/fetchPackage.ts
@@ -1,5 +1,5 @@
 import memoizePromise from "p-memoize";
-import { npmsApi } from "../constants/npmsApi";
+import { yarnNpmApi } from "../constants/npmApi";
 import { limitNpmsApiCallsConcurrency } from "./limitNpmsApiCallsConcurrency";
 import type { SearchResponse } from "../types/npms";
 
@@ -7,9 +7,14 @@ export const fetchPackage = memoizePromise(async (packageName: string) =>
   limitNpmsApiCallsConcurrency(
     async () =>
       (
-        await npmsApi
-          .get("search", { searchParams: { q: packageName, size: 1 } })
+        await yarnNpmApi
+          .get("-/v1/search", {
+            searchParams: {
+              text: packageName,
+              size: 1,
+            },
+          })
           .json<SearchResponse>()
-      ).results[0]
+      ).objects[0]
   )
 );

--- a/src/functions/getRandomPackage.ts
+++ b/src/functions/getRandomPackage.ts
@@ -2,23 +2,23 @@ import uniqueRandomArray from "unique-random-array";
 import randomItem from "random-item";
 import { topNpmKeywords } from "../constants/topNpmKeywords";
 import { fetchPackage } from "./fetchPackage";
-import { npmsApi } from "../constants/npmsApi";
+import { yarnNpmApi } from "../constants/npmApi";
 import type { SearchResponse } from "../types/npms";
 
 const getRandomKeyword = uniqueRandomArray(topNpmKeywords);
 
 export async function getRandomPackage() {
-  const searchResponse = await npmsApi
-    .get("search", {
+  const searchResponse = await yarnNpmApi
+    .get("-/v1/search", {
       searchParams: {
-        q: `keywords:${getRandomKeyword()},${getRandomKeyword()}`,
+        text: `keywords:${getRandomKeyword()},${getRandomKeyword()}`,
         size: 3,
       },
     })
     .json<SearchResponse>();
 
   const packageResult = await fetchPackage(
-    randomItem(searchResponse.results).package.name
+    randomItem(searchResponse.objects).package.name
   );
 
   return packageResult.package;

--- a/src/functions/getSimilarPackages.ts
+++ b/src/functions/getSimilarPackages.ts
@@ -30,7 +30,7 @@ export async function getSimilarPackages(packageName = "") {
     .filter(
       (result) =>
         result.total >= 5 &&
-        result.results[result.results.length - 1].score.final >= 0.45
+        result.objects[result.objects.length - 1].score.final >= 0.21
     )
     .sort((a, b) => a.total - b.total)
     .slice(0, 3);
@@ -115,14 +115,14 @@ export async function getSimilarPackages(packageName = "") {
   const mergedSearchResults = searchResponses
     .filter((result) => result.total >= 5)
     .reduce<SearchResult[]>(
-      (results, current) => [...results, ...(current.results ?? [])],
+      (results, current) => [...results, ...(current.objects ?? [])],
       []
     );
 
   const filteredSearchResults = mergedSearchResults
     .filter(
       (result) =>
-        result.score.final >= 0.45 &&
+        result.score.final >= 0.21 &&
         result.package.name !== packageName &&
         !result.package.name.includes(`${packageName}.`) &&
         !result.package.name.includes(`${packageName}-`) &&

--- a/src/functions/searchPackagesByKeywords.ts
+++ b/src/functions/searchPackagesByKeywords.ts
@@ -1,15 +1,15 @@
 import memoizePromise from "p-memoize";
-import { npmsApi } from "../constants/npmsApi";
+import { yarnNpmApi } from "../constants/npmApi";
 import { limitNpmsApiCallsConcurrency } from "./limitNpmsApiCallsConcurrency";
 import type { SearchResponse } from "../types/npms";
 
 export const searchPackagesByKeywords = memoizePromise(
   async (keywords: string[]) =>
     limitNpmsApiCallsConcurrency(async () =>
-      npmsApi
-        .get("search", {
+      yarnNpmApi
+        .get("-/v1/search", {
           searchParams: {
-            q: `keywords:${keywords.slice(0, 10).join(",")} not:deprecated`,
+            text: `keywords:${keywords.slice(0, 10).join(",")}`,
           },
         })
         .json<SearchResponse>()

--- a/src/functions/searchPackagesByTerms.ts
+++ b/src/functions/searchPackagesByTerms.ts
@@ -1,13 +1,15 @@
 import memoizePromise from "p-memoize";
-import { npmsApi } from "../constants/npmsApi";
+import { yarnNpmApi } from "../constants/npmApi";
 import { limitNpmsApiCallsConcurrency } from "./limitNpmsApiCallsConcurrency";
 import type { SearchResponse } from "../types/npms";
 
 export const searchPackagesByTerms = memoizePromise(async (terms: string[]) =>
   limitNpmsApiCallsConcurrency(async () =>
-    npmsApi
-      .get("search", {
-        searchParams: { q: `${terms.slice(0, 10).join(" ")} not:deprecated` },
+    yarnNpmApi
+      .get("-/v1/search", {
+        searchParams: {
+          text: `${terms.slice(0, 10).join(" ")}`,
+        },
       })
       .json<SearchResponse>()
   )

--- a/src/types/npms.d.ts
+++ b/src/types/npms.d.ts
@@ -111,7 +111,7 @@ export type SearchQuery = {
 
 export type SearchResponse = {
   total: number;
-  results: SearchResult[];
+  objects: SearchResult[];
 };
 
 export type SearchResult = {


### PR DESCRIPTION
This PR fixes the issue of outdated versions/descriptions of packages being listed in the search result.

Registry API Reference: https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md

More NPM Registry Mirrors at [github.com/amio/npm-mirrors](https://github.com/amio/npm-mirrors/blob/master/index.js)