### PR TITLE
fix for #280 Packages without description display the message "undefined"

### DIFF
--- a/src/components/PackageDetails.svelte
+++ b/src/components/PackageDetails.svelte
@@ -52,7 +52,7 @@
         <div class="col text-truncate d-inline-block w-300">
           <strong>{packageSearchResult.package.name}</strong>
           <span class="text-muted">
-            {packageSearchResult.package.description}
+            {packageSearchResult.package.description || "No description available"}
           </span>
         </div>
       </div>
@@ -108,7 +108,7 @@
               </a>
               <br />
             {/if}
-            {packageSearchResult.package.description}
+            {packageSearchResult.package.description || "No description available"}
             <br />
             <span class="badge-group mt-5" role="group">
               <a


### PR DESCRIPTION
"No description available" will be shown instead of undefined as below:
![image](https://user-images.githubusercontent.com/56339151/214207795-9ab63004-6d22-4452-be08-069efc6522db.png)

