### PR TITLE
Preserve the visible state of similar packages when clicking the "Show More" button

### DIFF
--- a/src/components/DependenciesTable.svelte
+++ b/src/components/DependenciesTable.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import PackageOnNpmWithoutDetails from "./PackageOnNpmWithoutDetails.svelte";
   import PackageLoadingProgressBar from "./PackageLoadingProgressBar.svelte";
   import NoSimilarPackagesSummary from "./NoSimilarPackagesSummary.svelte";
@@ -9,6 +9,10 @@
   import { t } from "svelte-i18n";
 
   const similarPackagesToDisplayPerBatch = 6;
+  const openedSimilarPackages = new Map<
+    import("../types/npms").SearchResult,
+    boolean
+  >();
   let dependencyPerSimilarPackagesDisplayedMap = {};
 </script>
 
@@ -65,7 +69,16 @@
                             <strong>{similarPackageName}</strong>
                           </summary>
                         {:then packageInfo}
-                          <PackageDetails packageSearchResult={packageInfo} />
+                          <PackageDetails
+                            packageSearchResult={packageInfo}
+                            open={openedSimilarPackages.get(packageInfo) ??
+                              false}
+                            onTogglePanel={(wasClosedWhenToggled) =>
+                              openedSimilarPackages.set(
+                                packageInfo,
+                                wasClosedWhenToggled
+                              )}
+                          />
                         {/await}
                       {:else}
                         <NoSimilarPackagesSummary />

--- a/src/components/PackageDetails.svelte
+++ b/src/components/PackageDetails.svelte
@@ -19,6 +19,7 @@
 
   export let packageSearchResult: SearchResult;
   export let open = false;
+  export let onTogglePanel: (wasClosedWhenToggled: boolean) => void = () => {};
 
   afterUpdate(() => lazyLoad.update());
 
@@ -58,7 +59,15 @@
   }
 </script>
 
-<details class="collapse-panel" data-test-id="package-details" {open}>
+<details
+  class="collapse-panel"
+  data-test-id="package-details"
+  {open}
+  on:click={({ currentTarget }) => {
+    onTogglePanel(!currentTarget.hasAttribute("open"));
+  }}
+  on:keypress={() => {}}
+>
   <summary class="collapse-header">
     <div class="container-fluid">
       <div class="row">


### PR DESCRIPTION
Previously, when clicking the "Show More" button, the full list of similar packages appeared hidden (as the list is reloaded). This PR fixes this behavior.

## How to test

In the preview environment, open a few similar packages, click the "Show More" button, and confirm if they remain open.

<img width="1225" alt="image" src="https://user-images.githubusercontent.com/418083/232215664-4904cdad-8ab0-40dc-af54-8677f5f5e752.png">
